### PR TITLE
Set gl version to 3.2, add a vertex array object.

### DIFF
--- a/src/test/scala/org/macrogl/examples/SingleTriangle.scala
+++ b/src/test/scala/org/macrogl/examples/SingleTriangle.scala
@@ -6,8 +6,13 @@ import org.macrogl._
 
 object SingleTriangle {
   def main(args: Array[String]) {
+    val contextAttributes = new ContextAttribs(3, 2).withForwardCompatible(true).withProfileCore(true)
+
     Display.setDisplayMode(new DisplayMode(800, 600))
-    Display.create()
+    Display.create(new PixelFormat, contextAttributes)
+
+    val vao = GL30.glGenVertexArrays()
+    GL30.glBindVertexArray(vao)
 
     val vertices = Array(
       -0.5f,  0.5f, 0.0f,  1, 0, 0,


### PR DESCRIPTION
Regarding VAO, from spec: "The default vertex array object (the name
zero) is also deprecated. Calling VertexAttribPointer when no buffer
object or no vertex array object is bound will generate an
INVALID_OPERATION error, as will calling any array drawing command when
no vertex array object is bound."
