### PR TITLE
Bump Scala version, break `inlineAndReset`.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -32,12 +32,13 @@ object MacroGLBuild extends Build {
     name := "macrogl",
     organization := "com.storm-enroute",
     version := "0.3-SNAPSHOT",
-    scalaVersion := "2.10.2",
+    scalaVersion := "2.11.0-RC4",
     scalacOptions ++= Seq(
       "-deprecation",
       "-unchecked",
       "-Xexperimental",
-      "-optimise"
+      "-optimise",
+      "-feature"
     ),
     scalaSource in Compile := baseDirectory.value / "src" / "macrogl" / "scala",
     unmanagedSourceDirectories in Compile += baseDirectory.value / "src" / "api-opengl" / "scala",

--- a/src/macrogl/scala/org/macrogl/AttributeBuffer.scala
+++ b/src/macrogl/scala/org/macrogl/AttributeBuffer.scala
@@ -3,7 +3,7 @@ package org.macrogl
 
 
 import language.experimental.macros
-import scala.reflect.macros.Context
+import scala.reflect.macros.whitebox.Context
 import scala.collection._
 
 

--- a/src/macrogl/scala/org/macrogl/FrameBuffer.scala
+++ b/src/macrogl/scala/org/macrogl/FrameBuffer.scala
@@ -3,7 +3,7 @@ package org.macrogl
 
 
 import language.experimental.macros
-import scala.reflect.macros.Context
+import scala.reflect.macros.whitebox.Context
 import scala.collection._
 
 
@@ -37,11 +37,11 @@ object FrameBuffer {
 
   class Binding private[FrameBuffer] () {
     object AttachTexture2D {
-      def foreach[U](f: Unit => U)(implicit gl: Macrogl) = macro FrameBuffer.bindTexture[U]
+      def foreach[U](f: Unit => U)(implicit gl: Macrogl): Unit = macro FrameBuffer.bindTexture[U]
     }
 
     object AttachRenderBuffer {
-      def foreach[U](f: Unit => U)(implicit gl: Macrogl) = macro FrameBuffer.bindRenderBuffer[U]
+      def foreach[U](f: Unit => U)(implicit gl: Macrogl): Unit = macro FrameBuffer.bindRenderBuffer[U]
     }
 
     def attachTexture2D(attachment: Int, t: Texture, level: Int) = AttachTexture2D

--- a/src/macrogl/scala/org/macrogl/MeshBuffer.scala
+++ b/src/macrogl/scala/org/macrogl/MeshBuffer.scala
@@ -3,7 +3,7 @@ package org.macrogl
 
 
 import language.experimental.macros
-import scala.reflect.macros.Context
+import scala.reflect.macros.whitebox.Context
 import scala.collection._
 
 

--- a/src/macrogl/scala/org/macrogl/misc.scala
+++ b/src/macrogl/scala/org/macrogl/misc.scala
@@ -3,7 +3,7 @@ package org
 
 
 import language.experimental.macros
-import scala.reflect.macros.Context
+import scala.reflect.macros.whitebox.Context
 
 
 
@@ -17,9 +17,9 @@ package macrogl {
 
   object Time {
 
-    def apply(thunk: Any) = macro Macros.timeForThunk
+    def apply(thunk: Any): Double = macro Macros.timeForThunk
 
-    def in(f: Double => Any)(thunk: Any) = macro Macros.timedThunk
+    def in(f: Double => Any)(thunk: Any): Any = macro Macros.timedThunk
 
   }
   
@@ -126,6 +126,7 @@ package macrogl {
   /* macros */
 
   object Macros {
+    import scala.language.implicitConversions
 
     implicit def c2utils(c: Context) = new Util[c.type](c)
   
@@ -321,7 +322,7 @@ package macrogl {
       val stats = for {
         (s, idx) <- settings.zipWithIndex
         sx = c.Expr[Int](s)
-        localName = newTermName("s$" + idx)
+        localName = TermName("s$" + idx)
         valexpr = reify {
           if (!gl.splice.isEnabled(sx.splice)) { gl.splice.enable(sx.splice); true } else false
         }
@@ -352,7 +353,7 @@ package macrogl {
       val stats = for {
         (s, idx) <- settings.zipWithIndex
         sx = c.Expr[Int](s)
-        localName = newTermName("s$" + idx)
+        localName = TermName("s$" + idx)
         valexpr = reify {
           if (gl.splice.isEnabled(sx.splice)) { gl.splice.disable(sx.splice); true } else false
         }
@@ -378,11 +379,14 @@ package macrogl {
     private[macrogl] class Util[C <: Context](val c: C) {
       import c.universe._
   
-      def inlineAndReset[T](expr: c.Expr[T]): c.Expr[T] =
-        c.Expr[T](c resetAllAttrs inlineApplyRecursive(expr.tree))
+      def inlineAndReset[T](expr: c.Expr[T]): c.Expr[T] = {
+        c.Expr[T](c untypecheck inlineApplyRecursive(expr.tree))
+        // FIXME
+        expr
+      }
   
       def inlineApplyRecursive(tree: Tree): Tree = {
-        val ApplyName = newTermName("apply")
+        val ApplyName = TermName("apply")
   
         object inliner extends Transformer {
           override def transform(tree: Tree): Tree = {
@@ -395,12 +399,12 @@ package macrogl {
                     // val a$0 = args(0); val b$0 = args(1); ...
                     val paramVals = params.zip(args).map {
                       case (ValDef(_, pName, _, _), a) =>
-                        ValDef(Modifiers(), newTermName("" + pName + "$0"), TypeTree(), a)
+                        ValDef(Modifiers(), TermName("" + pName + "$0"), TypeTree(), a)
                     }
                     // val a = a$0; val b = b$0
                     val paramVals2 = params.zip(args).map {
                       case (ValDef(_, pName, _, _), a) =>
-                        ValDef(Modifiers(), pName, TypeTree(), Ident(newTermName("" + pName + "$0")))
+                        ValDef(Modifiers(), pName, TypeTree(), Ident(TermName("" + pName + "$0")))
                     }
                     // The nested blocks avoid name clashes.
                     Block(paramVals, Block(paramVals2, body))

--- a/src/macroglex/scala/org/macrogl/ex/AttributeBuffer.scala
+++ b/src/macroglex/scala/org/macrogl/ex/AttributeBuffer.scala
@@ -4,7 +4,7 @@ package ex
 
 
 import language.experimental.macros
-import scala.reflect.macros.Context
+import scala.reflect.macros.whitebox.Context
 import scala.collection._
 
 

--- a/src/macroglex/scala/org/macrogl/ex/MeshBuffer.scala
+++ b/src/macroglex/scala/org/macrogl/ex/MeshBuffer.scala
@@ -4,7 +4,7 @@ package ex
 
 
 import language.experimental.macros
-import scala.reflect.macros.Context
+import scala.reflect.macros.whitebox.Context
 import scala.collection._
 
 


### PR DESCRIPTION
Time to get back at this :)

So yeah, about `resetAllAttrs`:

> 31) Removal of resetAllAttrs. resetAllAttrs is a very dangerous API and shouldn’t have been exposed in the first place. That’s why we have removed it without going through a deprecation cycle. There is however a publicly available replacement called resetLocalAttrs that should be sufficient in almost all cases, and we recommend using it instead.

Compiler also has the following to say about `resetLocalAttrs`:

> method resetLocalAttrs in trait Typers is deprecated: Use `c.untypecheck` instead

Unfortunately, neither of those work with single triangle example, :

> scala.reflect.internal.FatalError: symbol value acc does not exist in org.macrogl.examples.SingleTriangle.main

I'll be looking into this issue tomorrow, but since you may already know how to fix it, I'm posting it here.
