### PR TITLE
Fix `inlineAndReset`.

### DIFF
--- a/src/macrogl/scala/org/macrogl/misc.scala
+++ b/src/macrogl/scala/org/macrogl/misc.scala
@@ -379,11 +379,8 @@ package macrogl {
     private[macrogl] class Util[C <: Context](val c: C) {
       import c.universe._
   
-      def inlineAndReset[T](expr: c.Expr[T]): c.Expr[T] = {
-        val res = c untypecheck inlineApplyRecursive(expr.tree)
-        // FIXME hack
-        c.Expr[T](c parse showCode(res))
-      }
+      def inlineAndReset[T](expr: c.Expr[T]): c.Expr[T] =
+        c.Expr[T](inlineApplyRecursive(c untypecheck expr.tree))
   
       def inlineApplyRecursive(tree: Tree): Tree = {
         val ApplyName = TermName("apply")


### PR DESCRIPTION
To reset a symbol with `untypecheck`, a tree must contain symbol's
definition (i.e. it must be "local"). After the call to
`inlineApplyRecursive` lambda argument definiton was removed from the
tree, so it became external. To avoid that we must call `untypecheck`
before `inlineApplyRecursive`.

https://groups.google.com/forum/#!topic/scala-user/ZBaodlxc6ZE
